### PR TITLE
Fix flaky test for greedy allocator

### DIFF
--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocator.java
@@ -23,10 +23,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * A greedy allocator that returns the first Storage dir fitting the size of block to allocate. This
- * class serves as an example how to implement an allocator.
+ * A greedy allocator that returns the first Storage dir fitting the size of block to allocate.
  */
 @NotThreadSafe
 public final class GreedyAllocator implements Allocator {
@@ -45,6 +46,9 @@ public final class GreedyAllocator implements Allocator {
     mReviewer = Reviewer.Factory.create();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public StorageDirView allocateBlockWithView(long sessionId, long blockSize,
       BlockStoreLocation location, BlockMetadataView metadataView, boolean skipReview) {
@@ -53,29 +57,27 @@ public final class GreedyAllocator implements Allocator {
   }
 
   /**
-   * Allocates a block from the given block store location. The location can be a specific location,
-   * or {@link BlockStoreLocation#anyTier()} or {@link BlockStoreLocation#anyDirInTier(String)}.
+   * Allocates a block from the given block store location.
    *
    * @param sessionId the id of session to apply for the block allocation
    * @param blockSize the size of block in bytes
    * @param location the location in block store
-   * @return a {@link StorageDirView} in which to create the temp block meta if success,
-   *         null otherwise
+   * @param skipReview whether to skip review when allocating
+   * @return a {@link StorageDirView} if allocation succeeds, null otherwise
    */
   @Nullable
   private StorageDirView allocateBlock(long sessionId, long blockSize,
       BlockStoreLocation location, boolean skipReview) {
     Preconditions.checkNotNull(location, "location");
     if (location.equals(BlockStoreLocation.anyTier())) {
-      // When any tier is ok, loop over all tier views and dir views,
-      // and return a temp block meta from the first available dirview.
       for (StorageTierView tierView : mMetadataView.getTierViews()) {
-        for (StorageDirView dirView : tierView.getDirViews()) {
+        List<StorageDirView> sortedDirs = new ArrayList<>(tierView.getDirViews());
+        sortedDirs.sort((a, b) -> Integer.compare(a.getDirViewIndex(), b.getDirViewIndex()));
+        for (StorageDirView dirView : sortedDirs) {
           if (dirView.getAvailableBytes() >= blockSize) {
             if (skipReview || mReviewer.acceptAllocation(dirView)) {
               return dirView;
             } else {
-              // The allocation is rejected. Try the next dir.
               LOG.debug("Allocation rejected for anyTier: {}", dirView.toBlockStoreLocation());
             }
           }
@@ -88,13 +90,14 @@ public final class GreedyAllocator implements Allocator {
     if (!mediumType.equals(BlockStoreLocation.ANY_MEDIUM)
         && location.equals(BlockStoreLocation.anyDirInAnyTierWithMedium(mediumType))) {
       for (StorageTierView tierView : mMetadataView.getTierViews()) {
-        for (StorageDirView dirView : tierView.getDirViews()) {
+        List<StorageDirView> sortedDirs = new ArrayList<>(tierView.getDirViews());
+        sortedDirs.sort((a, b) -> Integer.compare(a.getDirViewIndex(), b.getDirViewIndex()));
+        for (StorageDirView dirView : sortedDirs) {
           if (dirView.getMediumType().equals(mediumType)
               && dirView.getAvailableBytes() >= blockSize) {
             if (skipReview || mReviewer.acceptAllocation(dirView)) {
               return dirView;
             } else {
-              // Try the next dir
               LOG.debug("Allocation rejected for anyDirInTierWithMedium: {}",
                       dirView.toBlockStoreLocation());
             }
@@ -107,13 +110,13 @@ public final class GreedyAllocator implements Allocator {
     String tierAlias = location.tierAlias();
     StorageTierView tierView = mMetadataView.getTierView(tierAlias);
     if (location.equals(BlockStoreLocation.anyDirInTier(tierAlias))) {
-      // Loop over all dir views in the given tier
-      for (StorageDirView dirView : tierView.getDirViews()) {
+      List<StorageDirView> sortedDirs = new ArrayList<>(tierView.getDirViews());
+      sortedDirs.sort((a, b) -> Integer.compare(a.getDirViewIndex(), b.getDirViewIndex()));
+      for (StorageDirView dirView : sortedDirs) {
         if (dirView.getAvailableBytes() >= blockSize) {
           if (skipReview || mReviewer.acceptAllocation(dirView)) {
             return dirView;
           } else {
-            // Try the next dir
             LOG.debug("Allocation rejected for anyDirInTier: {}",
                     dirView.toBlockStoreLocation());
           }
@@ -122,8 +125,6 @@ public final class GreedyAllocator implements Allocator {
       return null;
     }
 
-    // For allocation in a specific directory, we are not checking the reviewer,
-    // because we do not want the reviewer to reject it.
     int dirIndex = location.dir();
     StorageDirView dirView = tierView.getDirView(dirIndex);
     if (dirView != null && dirView.getAvailableBytes() >= blockSize) {

--- a/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocatorFixed.java:Zone.Identifier
+++ b/core/server/worker/src/main/java/alluxio/worker/block/allocator/GreedyAllocatorFixed.java:Zone.Identifier
@@ -1,0 +1,4 @@
+[ZoneTransfer]
+ZoneId=3
+ReferrerUrl=https://outlook.office.com/
+HostUrl=https://outlook.office.com/


### PR DESCRIPTION
mvn edu.illinois:nondex-maven-plugin:nondex -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testMapBooleanColumn

git clone https://github.com/TestingResearchIllinois/idoft
cd idoft
git checkout 99bcebbf56a6482915691cb08ffdacc413f274ac

grep ,ID,,,$ pr-data.csv | grep -v \\[ | shuf --random-source=<(while :; do echo skumar43@gmu.edu; done) | head


https://github.com/GoogleCloudPlatform/DataflowTemplates,5094c7b39de511c9ed441d9fde28553a88f68e4b,.,com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest.testMapBooleanColumn,ID,,,
git clone https://github.com/GoogleCloudPlatform/DataflowTemplates.git
cd DataflowTemplates
git checkout 5094c7b39de511c9ed441d9fde28553a88f68e4b

mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testMapBooleanColumn

https://github.com/Alluxio/alluxio,68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f,core/server/worker,alluxio.worker.block.allocator.GreedyAllocatorTest.allocateBlock,ID,,,
git clone https://github.com/Alluxio/alluxio.git
cd alluxio
git checkout 68fcda9dd2ca2181eb897e10ca02fa5bc3a3099f
mvn -pl core/server/worker edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=alluxio.worker.block.allocator.GreedyAllocatorTest#allocateBlock -DnondexRuns=20


### What is the purpose of this PR

This PR fixes a flaky test in `alluxio.worker.block.allocator.GreedyAllocatorTest#allocateBlock`. The test intermittently fails due to non-deterministic ordering when selecting storage directories, caused by iteration over an unsorted collection.

### Why the test fails
The allocator implementation iterated directly over the list of `StorageDirView` objects without enforcing any deterministic order. Because the backing collection does not guarantee iteration order, the test could pass or fail depending on the runtime environment. This leads to flaky behavior when using tools like NonDex or running on different JVMs.

### How to reproduce the test failure
Run the test with the NonDex Maven plugin. The following command consistently reproduces the failure:

```bash
mvn -pl core/server/worker edu.illinois:nondex-maven-plugin:2.1.1:nondex \
  -Dtest=alluxio.worker.block.allocator.GreedyAllocatorTest#allocateBlock \
  -DnondexRuns=20
```

### Expected results
The test should pass reliably when executed under shuffled runtime conditions.

### Actual results
Under NonDex, the test intermittently fails because directory selection is based on the default order of the internal collection.

### Description of fix
To ensure deterministic behavior, this PR introduces sorting of the `StorageDirView` list by their `dirViewIndex` before iterating. This guarantees consistent directory selection order, eliminating the flakiness caused by nondeterministic iteration.

